### PR TITLE
連続したデータ取得と表示

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,11 +54,16 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
+    // Retrofit
     implementation(libs.retrofit)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.retrofit2.kotlinx.serialization.converter)
     implementation(libs.okhttp)
     implementation(libs.coil.compose)
+
+    // Paging
+    implementation(libs.androidx.paging.runtime)
+    implementation(libs.androidx.paging.compose)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/paging_app_sample/data/AppContainer.kt
+++ b/app/src/main/java/com/example/paging_app_sample/data/AppContainer.kt
@@ -8,6 +8,8 @@ import retrofit2.Retrofit
 
 interface AppContainer {
     val recipesRepository: RecipesRepository
+    val recipesPagingSource: RecipesPagingSource
+    val recipesPagingDataRepository: RecipesPagingDataRepository
 }
 
 class DefaultAppContainer: AppContainer {
@@ -24,5 +26,13 @@ class DefaultAppContainer: AppContainer {
 
     override val recipesRepository: RecipesRepository by lazy {
         NetworkRecipesRepository(categoryRankApiService)
+    }
+
+    override val recipesPagingSource: RecipesPagingSource by lazy {
+        RecipesPagingSource(recipesRepository)
+    }
+
+    override val recipesPagingDataRepository: RecipesPagingDataRepository by lazy {
+        RecipesPagingDataRepository(recipesPagingSource)
     }
 }

--- a/app/src/main/java/com/example/paging_app_sample/data/Category.kt
+++ b/app/src/main/java/com/example/paging_app_sample/data/Category.kt
@@ -1,0 +1,81 @@
+package com.example.paging_app_sample.data
+
+/*
+  楽天レシピの大カテゴリ。今のところRICE_DISHES（ご飯もの）以外未使用。
+*/
+enum class LargeCategory(val id: String, val displayName: String){
+    MEAT("10", "肉"),
+    FISH("11", "魚"),
+    VEGETABLES("12", "野菜"),
+    OTHER_INGREDIENTS("13", "その他の食材"),
+    RICE_DISHES("14", "ご飯もの"),
+    PASTA("15", "パスタ"),
+    NOODLES("16", "麺・粉物料理"),
+    SOUP("17", "汁物・スープ"),
+    SALAD("18", "サラダ"),
+    SAUCE_SEASONING("19", "ソース・調味料・ドレッシング"),
+    BENTO("20", "お弁当"),
+    SWEETS("21", "お菓子"),
+    BREAD("22", "パン"),
+    HOT_POT("23", "鍋料理"),
+    EVENTS("24", "行事・イベント"),
+    WESTERN("25", "西洋料理"),
+    OTHER_PURPOSES("26", "その他の目的・シーン"),
+    BEVERAGES("27", "飲みもの"),
+    POPULAR_MENU("30", "人気メニュー"),
+    STANDARD_MEAT("31", "定番の肉料理"),
+    STANDARD_FISH("32", "定番の魚料理"),
+    EGG_DISHES("33", "卵料理"),
+    FRUITS("34", "果物"),
+    TOFU("35", "大豆・豆腐"),
+    QUICK_EASY("36", "簡単料理・時短"),
+    BUDGET_FRIENDLY("37", "節約料理"),
+    DAILY_MENU("38", "今日の献立"),
+    HEALTHY("39", "健康料理"),
+    COOKING_TOOLS("40", "調理器具"),
+    CHINESE("41", "中華料理"),
+    KOREAN("42", "韓国料理"),
+    ITALIAN("43", "イタリア料理"),
+    FRENCH("44", "フランス料理"),
+    ETHNIC("46", "エスニック料理・中南米"),
+    OKINAWAN("47", "沖縄料理"),
+    LOCAL_CUISINE("48", "日本各地の郷土料理"),
+    OSECHI("49", "おせち料理"),
+    CHRISTMAS("50", "クリスマス"),
+    HINAMATSURI("51", "ひな祭り"),
+    SPRING("52", "春（3月～5月）"),
+    SUMMER("53", "夏（6月～8月）"),
+    AUTUMN("54", "秋（9月～11月）"),
+    WINTER("55", "冬（12月～2月）");
+}
+
+/*
+  RICE_DISHES（ご飯もの）の中カテゴリ。
+*/
+enum class RiceDishMediumCategory(
+    val id: String,
+    val displayName: String,
+) {
+    SUSHI("129", "寿司"),
+    DONBURI("130", "丼物"),
+    FRIED_RICE("131", "チャーハン"),
+    TAKIKOMI_RICE("132", "炊き込みご飯"),
+    PORRIDGE("133", "おかゆ・雑炊類"),
+    ONIGIRI("134", "おにぎり"),
+    OMURICE("121", "オムライス"),
+    CHICKEN_RICE("122", "チキンライス"),
+    HASHED_BEEF_RICE("123", "ハヤシライス"),
+    TACO_RICE("124", "タコライス"),
+    LOCO_MOCO("125", "ロコモコ"),
+    PAELLA("126", "パエリア"),
+    PILAF("127", "ピラフ"),
+    OTHER_RICE_DISHES("271", "その他のごはん料理"),
+    HASHED_BEEF("368", "ハッシュドビーフ");
+
+    companion object {
+        fun fromOrdinal(ordinal: Int): RiceDishMediumCategory =
+            entries.getOrNull(ordinal) ?: HASHED_BEEF
+
+        fun getMaxOrdinal(): Int = entries.size - 1
+    }
+}

--- a/app/src/main/java/com/example/paging_app_sample/data/RecipesPagingDataRepository.kt
+++ b/app/src/main/java/com/example/paging_app_sample/data/RecipesPagingDataRepository.kt
@@ -1,0 +1,27 @@
+package com.example.paging_app_sample.data
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.example.paging_app_sample.model.Recipe
+import kotlinx.coroutines.flow.Flow
+
+class RecipesPagingDataRepository(
+    private val recipesPagingSource: RecipesPagingSource
+) {
+    fun getRecipes(): Flow<PagingData<Recipe>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = PAGE_SIZE,
+                enablePlaceholders = false
+            )
+        ) {
+            recipesPagingSource
+        }.flow
+    }
+
+    companion object {
+        // APIの仕様により4件ずつしかデータを取得できない
+        private const val PAGE_SIZE = 4
+    }
+}

--- a/app/src/main/java/com/example/paging_app_sample/data/RecipesPagingDataRepository.kt
+++ b/app/src/main/java/com/example/paging_app_sample/data/RecipesPagingDataRepository.kt
@@ -21,7 +21,7 @@ class RecipesPagingDataRepository(
     }
 
     companion object {
-        // APIの仕様により4件ずつしかデータを取得できない
+        // APIの仕様により4件ずつしかデータを取得できないため
         private const val PAGE_SIZE = 4
     }
 }

--- a/app/src/main/java/com/example/paging_app_sample/data/RecipesPagingSource.kt
+++ b/app/src/main/java/com/example/paging_app_sample/data/RecipesPagingSource.kt
@@ -1,0 +1,47 @@
+package com.example.paging_app_sample.data
+
+import android.util.Log
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.example.paging_app_sample.model.Recipe
+
+class RecipesPagingSource(
+    private val recipesRepository: RecipesRepository
+): PagingSource<Int, Recipe>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Recipe> {
+        try {
+            val currentPage = params.key ?: DEFAULT_KEY
+
+            val categoryId = getCategoryId(currentPage)
+            val recipes = recipesRepository.getRecipes(categoryId)
+
+            return LoadResult.Page(
+                data = recipes,
+                prevKey = if (currentPage == 0) null else currentPage - 1,
+                nextKey = if (currentPage >= RiceDishMediumCategory.getMaxOrdinal()) null else currentPage + 1
+            )
+        } catch (e: Exception) {
+            Log.d("RecipesPagingSource", "ERROR load() : " + e.message)
+            return LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Recipe>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    // "(大カテゴリID)-(中カテゴリID)"の形式のカテゴリIDを作成
+    private fun getCategoryId(currentPage: Int): String {
+        val mediumCategory = RiceDishMediumCategory.fromOrdinal(currentPage)
+        return LargeCategory.RICE_DISHES.id + "-" + mediumCategory.id
+    }
+
+    companion object {
+        // enumのordinalは0から始まるため0を指定
+        private const val DEFAULT_KEY = 0
+    }
+}

--- a/app/src/main/java/com/example/paging_app_sample/data/RecipesPagingSource.kt
+++ b/app/src/main/java/com/example/paging_app_sample/data/RecipesPagingSource.kt
@@ -4,17 +4,24 @@ import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.example.paging_app_sample.model.Recipe
+import kotlinx.coroutines.delay
 
 class RecipesPagingSource(
     private val recipesRepository: RecipesRepository
 ): PagingSource<Int, Recipe>() {
 
+    private var lastRequestTime: Long = 0
+
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Recipe> {
         try {
+            delayBetweenRequests()
+
             val currentPage = params.key ?: DEFAULT_KEY
 
             val categoryId = getCategoryId(currentPage)
             val recipes = recipesRepository.getRecipes(categoryId)
+
+            lastRequestTime = System.currentTimeMillis()
 
             return LoadResult.Page(
                 data = recipes,
@@ -34,14 +41,26 @@ class RecipesPagingSource(
         }
     }
 
-    // "(大カテゴリID)-(中カテゴリID)"の形式のカテゴリIDを作成
+    // APIの仕様により、リクエストを1秒に1回以下に制限
+    private suspend fun delayBetweenRequests() {
+        val currentTime = System.currentTimeMillis()
+        val currentInterval = currentTime - lastRequestTime
+        val minimumInterval = 1000
+
+        if (lastRequestTime != 0L && currentInterval < minimumInterval) {
+            delay(minimumInterval - currentInterval)
+            Log.d("RecipesPagingSource", "Delay currentInterval : {$currentInterval}")
+        }
+    }
+
+    // "(大カテゴリID)-(中カテゴリID)"形式のカテゴリIDを作成
     private fun getCategoryId(currentPage: Int): String {
         val mediumCategory = RiceDishMediumCategory.fromOrdinal(currentPage)
         return LargeCategory.RICE_DISHES.id + "-" + mediumCategory.id
     }
 
     companion object {
-        // enumのordinalは0から始まるため0を指定
+        // enumのordinalは0から始まるため
         private const val DEFAULT_KEY = 0
     }
 }

--- a/app/src/main/java/com/example/paging_app_sample/data/RecipesRepository.kt
+++ b/app/src/main/java/com/example/paging_app_sample/data/RecipesRepository.kt
@@ -5,15 +5,14 @@ import com.example.paging_app_sample.model.Recipe
 import com.example.paging_app_sample.network.CategoryRankApiService
 
 interface RecipesRepository {
-    suspend fun getRecipes(): List<Recipe>
+    suspend fun getRecipes(categoryId: String): List<Recipe>
 }
 
 class NetworkRecipesRepository(
     private val apiService: CategoryRankApiService
 ) : RecipesRepository {
-    override suspend fun getRecipes(): List<Recipe> {
+    override suspend fun getRecipes(categoryId: String): List<Recipe> {
         val applicationId = BuildConfig.apiKey
-        val categoryId = "14"
         val response = apiService.getRecipes(
             applicationId = applicationId,
             categoryId = categoryId

--- a/app/src/main/java/com/example/paging_app_sample/ui/PagingApp.kt
+++ b/app/src/main/java/com/example/paging_app_sample/ui/PagingApp.kt
@@ -17,7 +17,7 @@ fun PagingApp() {
                 .padding(innerPadding)
         ) {
             val recipesViewModel: RecipesViewModel = viewModel(factory = RecipesViewModel.Factory)
-            RecipesScreen(uiState = recipesViewModel.uiState)
+            RecipesScreen(viewModel = recipesViewModel)
         }
     }
 }

--- a/app/src/main/java/com/example/paging_app_sample/ui/RecipesScreen.kt
+++ b/app/src/main/java/com/example/paging_app_sample/ui/RecipesScreen.kt
@@ -1,6 +1,7 @@
 package com.example.paging_app_sample.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,12 +16,14 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.paging.LoadState
+import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.paging_app_sample.model.Recipe
 import com.example.paging_app_sample.ui.theme.Paging_app_sampleTheme
+import kotlinx.coroutines.flow.flowOf
 
 @Composable
 fun RecipesScreen(
@@ -70,15 +73,17 @@ fun ResultScreen(recipes: LazyPagingItems<Recipe>, modifier: Modifier = Modifier
             columns = GridCells.Fixed(2),
             modifier = modifier.fillMaxSize()
         ) {
-//            items(recipes) { recipe ->
-//                Column {
-//                    Photo(url = recipe.imageUrl)
-//                    Text(text = recipe.id)
-//                    Text(text = recipe.title)
-//                    Text(text = recipe.url)
-//                    Text(text = recipe.description)
-//                }
-//            }
+            items(recipes.itemCount) { index ->
+                recipes[index]?.let { recipe ->
+                    Column {
+                        Photo(url = recipe.imageUrl)
+                        Text(text = recipe.id)
+                        Text(text = recipe.title)
+                        Text(text = recipe.url)
+                        Text(text = recipe.description)
+                    }
+                }
+            }
         }
     }
 }
@@ -115,24 +120,28 @@ fun ErrorScreenPreview() {
 @Preview
 @Composable
 fun ResultScreenPreview() {
-    val sampleRecipes = listOf(
-        Recipe(
-            id = "0001",
-            title = "レシピ1",
-            url = "recipe1.com",
-            imageUrl = "recipe1-image.com",
-            description = "レシピ1の説明です。"
-        ),
-        Recipe(
-            id = "0002",
-            title = "レシピ2",
-            url = "recipe2.com",
-            imageUrl = "recipe2-image.com",
-            description = "レシピ2の説明です。"
+    val sampleRecipes = PagingData.from(
+        listOf(
+            Recipe(
+                id = "0001",
+                title = "レシピ1",
+                url = "recipe1.com",
+                imageUrl = "recipe1-image.com",
+                description = "レシピ1の説明です。"
+            ),
+            Recipe(
+                id = "0002",
+                title = "レシピ2",
+                url = "recipe2.com",
+                imageUrl = "recipe2-image.com",
+                description = "レシピ2の説明です。"
+            )
         )
     )
+    val flow = flowOf(sampleRecipes)
+    val items = flow.collectAsLazyPagingItems()
 
     Paging_app_sampleTheme {
-        // ResultScreen(recipes = sampleRecipes)
+        ResultScreen(recipes = items)
     }
 }

--- a/app/src/main/java/com/example/paging_app_sample/ui/RecipesScreen.kt
+++ b/app/src/main/java/com/example/paging_app_sample/ui/RecipesScreen.kt
@@ -1,13 +1,11 @@
 package com.example.paging_app_sample.ui
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,6 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.paging_app_sample.model.Recipe
@@ -23,14 +24,16 @@ import com.example.paging_app_sample.ui.theme.Paging_app_sampleTheme
 
 @Composable
 fun RecipesScreen(
-    uiState: UiState,
+    viewModel: RecipesViewModel,
     modifier: Modifier = Modifier
 ) {
-    when (uiState) {
-        is UiState.Loading -> LoadingScreen(modifier.fillMaxSize())
-        is UiState.Error -> ErrorScreen(modifier.fillMaxSize())
-        is UiState.Success -> ResultScreen(
-            uiState.recipes, modifier = modifier.fillMaxSize()
+    val response = viewModel.recipes.collectAsLazyPagingItems()
+
+    when (response.loadState.refresh) {
+        is LoadState.Loading -> LoadingScreen(modifier.fillMaxSize())
+        is LoadState.Error -> ErrorScreen(modifier.fillMaxSize())
+        else -> ResultScreen(
+            response, modifier = modifier.fillMaxSize()
         )
     }
 }
@@ -61,21 +64,21 @@ fun ErrorScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun ResultScreen(recipes: List<Recipe>, modifier: Modifier = Modifier) {
+fun ResultScreen(recipes: LazyPagingItems<Recipe>, modifier: Modifier = Modifier) {
     Surface {
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),
             modifier = modifier.fillMaxSize()
         ) {
-            items(recipes) { recipe ->
-                Column {
-                    Photo(url = recipe.imageUrl)
-                    Text(text = recipe.id)
-                    Text(text = recipe.title)
-                    Text(text = recipe.url)
-                    Text(text = recipe.description)
-                }
-            }
+//            items(recipes) { recipe ->
+//                Column {
+//                    Photo(url = recipe.imageUrl)
+//                    Text(text = recipe.id)
+//                    Text(text = recipe.title)
+//                    Text(text = recipe.url)
+//                    Text(text = recipe.description)
+//                }
+//            }
         }
     }
 }
@@ -130,6 +133,6 @@ fun ResultScreenPreview() {
     )
 
     Paging_app_sampleTheme {
-        ResultScreen(recipes = sampleRecipes)
+        // ResultScreen(recipes = sampleRecipes)
     }
 }

--- a/app/src/main/java/com/example/paging_app_sample/ui/RecipesViewModel.kt
+++ b/app/src/main/java/com/example/paging_app_sample/ui/RecipesViewModel.kt
@@ -1,51 +1,33 @@
 package com.example.paging_app_sample.ui
 
-import android.util.Log
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import com.example.paging_app_sample.RecipesApplication
-import com.example.paging_app_sample.data.RecipesRepository
-import com.example.paging_app_sample.model.Recipe
-import kotlinx.coroutines.launch
+import com.example.paging_app_sample.data.RecipesPagingDataRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 
-sealed interface UiState {
-    data class Success(val recipes: List<Recipe>) : UiState
-    object Error : UiState
-    object Loading : UiState
-}
+class RecipesViewModel(repository: RecipesPagingDataRepository) : ViewModel() {
 
-class RecipesViewModel(private val recipesRepository: RecipesRepository) : ViewModel() {
-    var uiState: UiState by mutableStateOf(UiState.Loading)
-        private set
-
-    init {
-        getRecipes()
-    }
-
-    private fun getRecipes() {
-        viewModelScope.launch {
-            uiState = try {
-                val result = recipesRepository.getRecipes()
-                UiState.Success(result)
-            } catch (e: Exception) {
-                Log.d("RecipesViewModel", "ERROR getRecipes() :" + e.message)
-                UiState.Error
-            }
-        }
-    }
+    val recipes = repository.getRecipes()
+        .cachedIn(viewModelScope)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = PagingData.empty()
+        )
 
     companion object {
         val Factory: ViewModelProvider.Factory = viewModelFactory {
             initializer {
                 val application = (this[APPLICATION_KEY] as RecipesApplication)
-                val repository = application.container.recipesRepository
+                val repository = application.container.recipesPagingDataRepository
                 RecipesViewModel(repository)
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.0"
 composeBom = "2024.04.01"
 okhttp = "4.11.0"
+pagingRuntime = "3.3.6"
 retrofit = "2.11.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
 secretsGradlePlugin = "2.0.1"
@@ -18,6 +19,8 @@ secretsGradlePlugin = "2.0.1"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "pagingRuntime" }
+androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "pagingRuntime" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
### 対応内容
- Pagingの導入
- 「ご飯もの」に含まれるレシピを、中カテゴリごとに上位4つずつ取得しリストで表示する

### スクリーンショット
<img src="https://github.com/user-attachments/assets/5b23e57d-21a6-4e8f-9542-d82f5ff6d623" width=250>

